### PR TITLE
Enable GitHub Pages build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - run: cp dist/index.html dist/404.html
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@
 2. Run `npm install` to install dependencies.
 3. Use `npm run dev` to start the development server.
 4. Use the theme toggle in the navigation bar to switch between light and dark modes.
+
+## GitHub Pages
+
+This project is configured to deploy automatically to **GitHub Pages** from the
+`main` branch. On every push to `main`, a workflow builds the site with Vite and
+publishes the contents of the `dist` directory. The deployed site will be
+available at:
+
+```
+https://<your-github-username>.github.io/signalthread-landing/
+```
+
+Make sure GitHub Pages is enabled for the repository and uses the `GitHub Pages`
+workflow as its source.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === 'development' ? '/' : '/signalthread-landing/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- set Vite `base` path for GitHub Pages
- create a GitHub Actions workflow to build and deploy to Pages
- document how the site is published

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ef4e88a5c8321b3b741f9365e809f