### PR TITLE
Update GH Pages build with Supabase env vars

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,6 +25,9 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
       - run: cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- inject Supabase credentials during GH Pages build

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f178158048321a136d61729ba192d