### PR TITLE
Fix logo path

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,7 +10,7 @@ export const Navbar = () => {
           {/* Logo/Favicon */}
           <div className="flex items-center gap-2">
             <img
-              src="/signalthread.svg"
+              src={`${import.meta.env.BASE_URL}signalthread.svg`}
               alt="SignalThread logo"
               className="h-8 w-8"
             />


### PR DESCRIPTION
## Summary
- make Navbar logo use `import.meta.env.BASE_URL` for static path

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f2a57b72c8321a2ffa9c0ed49e72b