### PR TITLE
Fix dark/light mode toggle icons

### DIFF
--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -11,8 +11,8 @@ export function ModeToggle() {
       size="icon"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
     >
-      <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <Sun className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <Moon className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   );


### PR DESCRIPTION
## Summary
- swap CSS classes so that dark mode shows a sun and light mode shows a moon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f2f8f9ee48321b7dfd06ae89cd952